### PR TITLE
Avoided listing the connection type (HTTP or HTTPS) on the src attribute...

### DIFF
--- a/mdx_video.py
+++ b/mdx_video.py
@@ -50,7 +50,7 @@ class VideoExtension(markdown.Extension):
 
 class Dailymotion(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
-        url = 'http://www.dailymotion.com/embed/video/%s' % m.group('dailymotionid')
+        url = '//www.dailymotion.com/embed/video/%s' % m.group('dailymotionid')
         width = self.ext.config['dailymotion_width'][0]
         height = self.ext.config['dailymotion_height'][0]
         return render_iframe(url, width, height)
@@ -58,7 +58,7 @@ class Dailymotion(markdown.inlinepatterns.Pattern):
 
 class Metacafe(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
-        url = 'http://www.metacafe.com/embed/%s/' % m.group('metacafeid')
+        url = '//www.metacafe.com/embed/%s/' % m.group('metacafeid')
         width = self.ext.config['metacafe_width'][0]
         height = self.ext.config['metacafe_height'][0]
         return render_iframe(url, width, height)
@@ -66,7 +66,7 @@ class Metacafe(markdown.inlinepatterns.Pattern):
 
 class Veoh(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
-        url = 'http://www.veoh.com/videodetails2.swf?permalinkId=%s' % m.group('veohid')
+        url = '//www.veoh.com/videodetails2.swf?permalinkId=%s' % m.group('veohid')
         width = self.ext.config['veoh_width'][0]
         height = self.ext.config['veoh_height'][0]
         return flash_object(url, width, height)
@@ -74,7 +74,7 @@ class Veoh(markdown.inlinepatterns.Pattern):
 
 class Vimeo(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
-        url = 'http://player.vimeo.com/video/%s' % m.group('vimeoid')
+        url = '//player.vimeo.com/video/%s' % m.group('vimeoid')
         width = self.ext.config['vimeo_width'][0]
         height = self.ext.config['vimeo_height'][0]
         return render_iframe(url, width, height)
@@ -90,7 +90,7 @@ class Yahoo(markdown.inlinepatterns.Pattern):
 
 class Youtube(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
-        url = 'http://www.youtube.com/embed/%s' % m.group('youtubeid')
+        url = '//www.youtube.com/embed/%s' % m.group('youtubeid')
         width = self.ext.config['youtube_width'][0]
         height = self.ext.config['youtube_height'][0]
         return render_iframe(url, width, height)


### PR DESCRIPTION
... of rendered iframes because browsers now do not enable the iframe unless its source connection type matches the parent page's connection type. (https://blog.mozilla.org/security/2013/05/16/mixed-content-blocking-in-firefox-aurora/)