### PR TITLE
Fix default config loading.

### DIFF
--- a/mdx_video.py
+++ b/mdx_video.py
@@ -22,7 +22,7 @@ class VideoExtension(markdown.Extension):
         }
 
         # Override defaults with user settings
-        if "configs" in kwargs:
+        if kwargs.get('configs', None):
             for key, value in kwargs["configs"]:
                 self.setConfig(key, value)
 


### PR DESCRIPTION
If no config is specified, then `mdx_video` fail to load. See:

``` python
$ python
Python 2.7.8 (default, Oct 20 2014, 15:05:19) 
[GCC 4.9.1] on linux2
>>> import markdown
>>> markdown.__version__.version
'2.6.2'
>>> markdown.markdown('', extensions=['mdx_video'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/markdown/__init__.py", line 493, in markdown
    md = Markdown(*args, **kwargs)
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/markdown/__init__.py", line 159, in __init__
    configs=kwargs.get('extension_configs', {}))
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/markdown/__init__.py", line 185, in registerExtensions
    ext = self.build_extension(ext, configs.get(ext, {}))
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/markdown/__init__.py", line 291, in build_extension
    return module.makeExtension(**configs)
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/mdx_video.py", line 128, in makeExtension
    return VideoExtension(configs=configs)
  File "/home/kevin/virtualenvs/blog/local/lib/python2.7/site-packages/mdx_video.py", line 26, in __init__
    for key, value in kwargs["configs"]:
TypeError: 'NoneType' object is not iterable
```

This issue was introduced in commit cfaf96d8caadfeb0e226a1b9f034cbbc74245328 .
