### PR TITLE
Make render_iframe work with responsive layouts

### DIFF
--- a/mdx_video.py
+++ b/mdx_video.py
@@ -97,13 +97,16 @@ class Youtube(markdown.inlinepatterns.Pattern):
 
 
 def render_iframe(url, width, height):
+    div = etree.Element('div')
+    div.set('class', 'mdx-video-container')
     iframe = etree.Element('iframe')
-    iframe.set('width', width)
-    iframe.set('height', height)
     iframe.set('src', url)
     iframe.set('allowfullscreen', 'true')
+    iframe.set('webkitallowfullscreen', 'true')
+    iframe.set('mozallowfullscreen', 'true')
     iframe.set('frameborder', '0')
-    return iframe
+    div.append(iframe)
+    return div
 
 
 def flash_object(url, width, height):

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+.mdx-video-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+    max-width: 100%;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.mdx-video-container iframe, .mdx-video-container object, .mdx-video-container embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
In moving one of my sites that uses mdx-video to a responsive layout, I noticed that all of the width/height parameters for mdx-video output are hardcoded. This doesn't play too well with responsive stuff, so I decided to see if I could fix it. This pull request is more a request for comments than something I'm expecting to land, since I threw this together in like 5 minutes.

Basically, all I've done is taken some of the output I got from http://embedresponsively.com and adapt mdx-video's output to that. I've only tested it for youtube and vimeo, but it works well enough there. 

The main problem is the CSS that's required to go with it. Right now, I've just got the styling in an outside css file, that I add to the styles of whatever pages I need it for. However, it might be nice to add that into the page via a style tag only when mdx-video is called for the first time? Not sure if markdown extensions can keep state during parsing though.
